### PR TITLE
Add user file upload on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # moodleSIL
+
+## Carga de archivos de usuarios
+
+Al registrar un estudiante es posible subir una imagen o archivo PDF. Los archivos se guardan en la carpeta `uploads/` dentro de un subdirectorio con el ID del usuario. En la base de datos solo se registra la ruta relativa del archivo.


### PR DESCRIPTION
## Summary
- allow uploading an image or PDF when creating a student
- create `uploads/<ID>` folders and store relative path in `mdl_user_files`
- document file upload location in README

## Testing
- `php -l registrar-estudiante.php`

------
https://chatgpt.com/codex/tasks/task_e_68841a9ffdb0832e89c2ce7e3ebe15b8