### PR TITLE
Add file preview modal in student list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # moodleSIL
+
+## Carga de archivos de usuarios
+
+Al registrar un estudiante es posible subir una imagen o archivo PDF. Los archivos se guardan en la carpeta `uploads/` dentro de un subdirectorio con el ID del usuario. En la base de datos solo se registra la ruta relativa del archivo.
+
+En la página de lista de estudiantes hay un botón para ver el archivo subido. Al abrirlo se muestra un modal con una vista previa y un enlace para descargarlo.

--- a/ajax/editar_usuario_form.php
+++ b/ajax/editar_usuario_form.php
@@ -1,0 +1,50 @@
+<?php
+require_once '../db.php';
+
+$id = intval($_GET['id'] ?? 0);
+
+$stmt = $pdo->prepare("SELECT id, username, firstname, lastname, email FROM mdl_user WHERE id = ?");
+$stmt->execute([$id]);
+$user = $stmt->fetch();
+
+if (!$user) {
+    echo 'Usuario no encontrado';
+    exit;
+}
+?>
+<form id="formEditarUsuario">
+  <input type="hidden" name="id" value="<?= $user['id'] ?>">
+  <div class="mb-3">
+    <label class="form-label">Nombre de usuario</label>
+    <input type="text" class="form-control" name="username" value="<?= htmlspecialchars($user['username']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Nombres</label>
+    <input type="text" class="form-control" name="firstname" value="<?= htmlspecialchars($user['firstname']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Apellidos</label>
+    <input type="text" class="form-control" name="lastname" value="<?= htmlspecialchars($user['lastname']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Correo</label>
+    <input type="email" class="form-control" name="email" value="<?= htmlspecialchars($user['email']) ?>" required>
+  </div>
+  <button type="button" class="btn btn-primary" onclick="guardarUsuario()">Guardar</button>
+</form>
+<script>
+function guardarUsuario() {
+  const form = document.getElementById('formEditarUsuario');
+  fetch('./ajax/actualizar_usuario.php', {
+    method: 'POST',
+    body: new FormData(form)
+  })
+    .then(res => res.text())
+    .then(resp => {
+      if (resp.trim() === 'ok') {
+        cargarEstudiantes();
+        bootstrap.Modal.getInstance(document.getElementById('modalEditar')).hide();
+      }
+    });
+}
+</script>


### PR DESCRIPTION
## Summary
- load each user's file path in `ajax/estudiantes.php`
- add buttons and modal to preview or download the file
- provide editing form endpoint `ajax/editar_usuario_form.php`
- document file viewer in README

## Testing
- `php -l ajax/estudiantes.php`
- `php -l ajax/editar_usuario_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68841a9ffdb0832e89c2ce7e3ebe15b8